### PR TITLE
feat: use rules_jvm_external for dep fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,22 @@
 To use the Avro rules, add the following to your projects `WORKSPACE` file
 
 ```python
-rules_avro_version="4413a57db613a1eba5d5a56ca48d7c6655726bb8" # update this as needed
+# rules_avro depends on rules_jvm_external: https://github.com/bazelbuild/rules_jvm_external
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+RULES_JVM_EXTERNAL_TAG = "2.7"
+
+RULES_JVM_EXTERNAL_SHA = "f04b1466a00a2845106801e0c5cec96841f49ea4e7d1df88dc8e4bf31523df74"
+
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+)
+
+
+rules_avro_version="c9bfdda9e909e4213abc595a07353e0d23128bbd" # update this commit hash as needed
 
 git_repository(
     name = "io_bazel_rules_avro",
@@ -22,6 +37,8 @@ git_repository(
 
 load("@io_bazel_rules_avro//avro:avro.bzl", "avro_repositories")
 avro_repositories()
+# or specify a version
+avro_repositories(version = "1.8.2")
 ```
 
 Then in your `BUILD` file, just add the following so the rules will be available:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,17 @@
 workspace(name = "io_bazel_rules_avro")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+RULES_JVM_EXTERNAL_TAG = "2.7"
+
+RULES_JVM_EXTERNAL_SHA = "f04b1466a00a2845106801e0c5cec96841f49ea4e7d1df88dc8e4bf31523df74"
+
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+)
+
 load('//avro:avro.bzl', 'avro_repositories')
 avro_repositories()

--- a/avro/avro.bzl
+++ b/avro/avro.bzl
@@ -1,3 +1,26 @@
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@rules_jvm_external//:defs.bzl", "artifact")
+load("@rules_jvm_external//:specs.bzl", "maven")
+
+MAVEN_REPO_NAME = "avro"
+AVRO_TOOLS = ("org.apache.avro", "avro-tools")
+AVRO = ("org.apache.avro", "avro")
+
+def _format_maven_jar_name(group_id, artifact_id):
+    """
+    group_id: str
+    artifact_id: str
+    """
+    return ("%s_%s" % (group_id, artifact_id)).replace(".", "_").replace("-", "_")
+
+def _format_maven_jar_dep_name(group_id, artifact_id, repo_name = "maven"):
+    """
+    group_id: str
+    artifact_id: str
+    repo_name: str = "maven"
+    """
+    return "@%s//:%s" % (repo_name, _format_maven_jar_name(group_id, artifact_id))
+
 def _commonprefix(m):
     if not m: return ''
     s1 = min(m)
@@ -10,29 +33,26 @@ def _commonprefix(m):
             return s1[:i]
     return s1
 
-def avro_repositories():
-  # for code generation
-  native.maven_jar(
-      name = "org_apache_avro_avro_tools",
-      artifact = "org.apache.avro:avro-tools:1.8.1",
-      sha1 = "361c32d4cad8dea8e5944d588e7d410f9f2a7114",
-  )
-  native.bind(
-      name = 'io_bazel_rules_avro/dependency/avro_tools',
-      actual = '@org_apache_avro_avro_tools//jar',
-  )
-
-  # for code compilation
-  native.maven_jar(
-      name = "org_apache_avro_avro",
-      artifact = "org.apache.avro:avro:1.8.1",
-      sha1 = "f4e11d00055760dca33daab193192bd75cc87b59",
-  )
-  native.bind(
-      name = 'io_bazel_rules_avro/dependency/avro',
-      actual = '@org_apache_avro_avro//jar',
-  )
-
+def avro_repositories(version = "1.8.1"):
+    """
+    version: str = "1.8.1" - the version of avro to fetch
+    """
+    artifacts = [
+        maven.artifact(
+            group = group_id,
+            artifact = artifact_id,
+            version = version,
+        )
+        for [group_id, artifact_id] in [AVRO, AVRO_TOOLS]
+    ]
+    maven_install(
+        name = MAVEN_REPO_NAME,
+        fetch_sources = True,
+        artifacts = artifacts,
+        repositories = [
+            "http://central.maven.org/maven2/",
+        ],
+    )
 
 def _new_generator_command(ctx, src_dir, gen_dir):
   java_path = ctx.attr._jdk[java_common.JavaRuntimeInfo].java_executable_exec_path
@@ -81,7 +101,7 @@ def _impl(ctx):
       ctx.file._avro_tools,
     ]
 
-    ctx.action(
+    ctx.actions.run_shell(
         inputs = inputs,
         outputs = [ctx.outputs.codegen],
         command = " && ".join(commands),
@@ -106,7 +126,13 @@ avro_gen = rule(
                 ),
         "_avro_tools": attr.label(
             cfg = "host",
-            default = Label("//external:io_bazel_rules_avro/dependency/avro_tools"),
+            default = Label(
+                _format_maven_jar_dep_name(
+                    group_id = AVRO_TOOLS[0],
+                    artifact_id = AVRO_TOOLS[1],
+                    repo_name = MAVEN_REPO_NAME,
+                ),
+            ),
             allow_single_file = True,
         )
     },
@@ -130,7 +156,13 @@ def avro_java_library(
         name=name,
         srcs=[name + '_srcjar'],
         deps = [
-          Label("//external:io_bazel_rules_avro/dependency/avro")
+          Label(
+              _format_maven_jar_dep_name(
+                  group_id = AVRO[0],
+                  artifact_id = AVRO[1],
+                  repo_name = MAVEN_REPO_NAME,
+              ),
+          ),
         ],
         visibility=visibility,
     )


### PR DESCRIPTION
Closes #6 

I'm pretty new to the Bazel world, so please let me know what needs to change! 

Changes:
* use rules_jvm_external to fetch maven dependencies, under `@avro//` 
* use `ctx.actions.run_shell()` instead of `ctx.action()` - this was to make it run on Bazel 0.28, though happy to submit that in a separate PR