### PR TITLE
Support external specified avro tools jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Generates `.srcjar` containing generated `.java` source files from a collection 
         <p>set the encoding of output files.</p>
       </td>
     </tr>
+    <tr>
+      <td><code>avro_tools</code></td>
+      <td>
+        <code>Label, optional</code>
+        <p>Label to the runnable Avro tools jar. Default, uses the tools jar associated with the downloaded avro 
+        version via `avro_repository`</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -107,6 +115,9 @@ Generates `.srcjar` containing generated `.java` source files from a collection 
 avro_java_library(name, srcs, strings, encoding)
 ```
 
-Same as above except that the outputs include those provided by `java_library` rules.
+Same as above except
+  * instead of `avro_tools`, provide `avro_libs` as a dict(core, tools) of Labels for the avro libraries.
+    * See tests for an example the re-uses the downloaded library explicitly
+  * the outputs include those provided by `java_library` rules.
 
 Meetup 2017

--- a/test/BUILD
+++ b/test/BUILD
@@ -23,3 +23,13 @@ avro_java_library(
         ["src/**/*.avsc"],
     )
 )
+avro_java_library(
+    name = "custom_tool",
+    strings = True,
+    srcs = glob(
+        ["src/**/*.avsc"],
+    ),
+    # adds the dependency on the downloaded avro library to the java_library, so the sources can compile
+    # while using the specified tools to compile the schema
+     avro_libs = {"core": "@avro//:org_apache_avro_avro", "tools": "@avro//:org_apache_avro_avro_tools"}
+)


### PR DESCRIPTION
This is helpful when you already pull down an avro
version from the non-standard maven repo and you
just want to use that in the toolchain. Helps ensure
that you have the same version everywhere in your build,
rather than using a maybe close, but not exactly the same,
version from maven central.