### PR TITLE
Properly escape strings

### DIFF
--- a/avro/avro.bzl
+++ b/avro/avro.bzl
@@ -129,7 +129,7 @@ def _impl(ctx):
         "mkdir -p {gen_dir}".format(gen_dir=gen_dir),
         _new_generator_command(ctx, src_dir, gen_dir),
         # forcing a timestamp for deterministic artifacts
-        "find {gen_dir} -exec touch -t 198001010000 {{}} \;".format(
+        "find {gen_dir} -exec touch -t 198001010000 {{}} \\;".format(
           gen_dir=gen_dir
         ),
         "{jar} cMf {output} -C {gen_dir} .".format(


### PR DESCRIPTION
With Bazel 4.0.0 string escaping is more strict, adding this extra \ makes things work, while still giving the same results