### PR TITLE
Add support for .avpr and .avdl

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -1,4 +1,4 @@
-load("//avro:avro.bzl", "avro_gen", "avro_java_library")
+load("//avro:avro.bzl", "avro_gen", "avro_idl_gen", "avro_idl_schema", "avro_java_library")
 
 avro_java_library(
     name = "defaults",
@@ -32,4 +32,24 @@ avro_java_library(
     # adds the dependency on the downloaded avro library to the java_library, so the sources can compile
     # while using the specified tools to compile the schema
      avro_libs = {"core": "@avro//:org_apache_avro_avro", "tools": "@avro//:org_apache_avro_avro_tools"}
+)
+
+avro_idl_gen(
+    name = "idl",
+    srcs = glob(
+        ["src/**/*.avdl"],
+    ),
+    imports = glob(
+        ["src/**/*.avsc"],
+    )
+)
+
+avro_idl_schema(
+    name = "schema",
+    srcs = glob(
+        ["src/**/*.avdl"],
+    ),
+    imports = glob(
+        ["src/**/*.avsc"],
+    )
 )

--- a/test/src/User.avdl
+++ b/test/src/User.avdl
@@ -1,0 +1,3 @@
+protocol UserProto {
+    import schema "User.avsc";
+}


### PR DESCRIPTION
This PR:
* adds a new rule `avro_idl_gen` which compiles `.avdl`->.`java`. 
* adds an option to the `avro_gen` rule to support compiling `.avpr` -> `.java`

Please advise on any testing that should be added.