### PR TITLE
pass excluded_artifacts down to maven_install

### DIFF
--- a/avro/avro.bzl
+++ b/avro/avro.bzl
@@ -75,9 +75,10 @@ def _common_dir(dirs):
 
     return _join_list(shortest, "/")
 
-def avro_repositories(version = "1.9.1"):
+def avro_repositories(version = "1.9.1", excluded_artifacts = []):
     """
     version: str = "1.9.1" - the version of avro to fetch
+    excluded_artifacts = [] - artifacts to have maven_install exclude
     """
     artifacts = [
         maven.artifact(
@@ -91,6 +92,7 @@ def avro_repositories(version = "1.9.1"):
         name = MAVEN_REPO_NAME,
         fetch_sources = True,
         artifacts = artifacts,
+        excluded_artifacts = excluded_artifacts,
         repositories = [
             "https://repo1.maven.org/maven2/",
         ],


### PR DESCRIPTION
We need to exclude some artifacts from the repo built by `rules_jvm_external`.
To do this, we just need the option to pass `excluded_artifacts` down to `maven_install`.