### PR TITLE
fix macOS `printf` and escape sequence issues

### DIFF
--- a/avro/avro.bzl
+++ b/avro/avro.bzl
@@ -274,7 +274,7 @@ def _gen_impl(ctx):
         "pushd {gen_dir}".format(gen_dir = gen_dir),
         # Sort the entries when zipping in order to guarantee deterministic outputs.
         # Note that we use zip instead of jar because jar does not seem to respect insert ordering.
-        "find . -printf '%P\n' | sort |  xargs \"${{base_dir}}/{zipper}\" c \"${{base_dir}}/{output}\"".format(
+        "find . -print | sort |  xargs \"${{base_dir}}/{zipper}\" c \"${{base_dir}}/{output}\"".format(
             zipper = ctx.executable._zipper.path,
             output = ctx.outputs.codegen.path,
         ),

--- a/avro/avro.bzl
+++ b/avro/avro.bzl
@@ -267,7 +267,7 @@ def _gen_impl(ctx):
         "mkdir -p {gen_dir}".format(gen_dir=gen_dir),
         _new_generator_command(ctx, src_dir, ctx.attr.type, gen_dir),
         # forcing a timestamp for deterministic artifacts
-        "find {gen_dir} -exec touch -t 198001010000 {{}} \\\\;".format(
+        "find {gen_dir} -exec touch -t 198001010000 {{}} \\;".format(
           gen_dir=gen_dir
         ),
         "base_dir=$(pwd)",


### PR DESCRIPTION
1. This error comes in mac machine: `find: -printf: unknown primary or operator`

2. I see this error with `\\\\`

```
/bin/bash: -c: line 0: syntax error near unexpected token `&&'
/bin/bash: -c: line 0: `rm -rf bazel-out/darwin_arm64-fastbuild/bin/<path_to_project>_srcjar_codegen.srcjar-tmp && mkdir -p bazel-out/darwin_arm64-fastbuild/bin/<path_to_project>_srcjar_codegen.srcjar-tmp && /bin/java -jar bazel-out/darwin_arm64-opt-exec-ST-a828a81199fe/bin/external/avro/org/apache/avro/avro-tools/1.11.3/processed_avro-tools-1.11.3.jar compile  -string schema <path_to_project_file>.avsc bazel-out/darwin_arm64-fastbuild/bin/<path_to_project>_srcjar_codegen.srcjar-tmp && find bazel-out/darwin_arm64-fastbuild/bin/<path_to_project>_srcjar_codegen.srcjar-tmp -exec touch -t 198001010000 {} \\; && base_dir=$(pwd) && pushd bazel-out/darwin_arm64-fastbuild/bin/<path_to_project>.srcjar-tmp &&....
```

There's extra `\\` causing this error for me.

