### PR TITLE
fix: update avro library macros to propagate common rule attributes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,6 +3,7 @@ module(
     version = "0.1.0",
 )
 
+bazel_dep(name = "aspect_bazel_lib", version = "2.19.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_java", version = "7.12.5")
 bazel_dep(name = "rules_jvm_external", version = "6.5")

--- a/README.md
+++ b/README.md
@@ -16,9 +16,44 @@
 To use the Avro rules, add the following to your projects `WORKSPACE` file
 
 ```python
-# rules_avro depends on rules_jvm_external: https://github.com/bazelbuild/rules_jvm_external
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# rules_avro depends on aspect_bazel_lib: https://github.com/bazel-contrib/bazel-lib
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "63ae96db9b9ea3821320e4274352980387dc3218baeea0387f7cf738755d0f16",
+    strip_prefix = "bazel-lib-2.19.1",
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.19.1/bazel-lib-v2.19.1.tar.gz",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
+
+# Required bazel-lib dependencies
+
+aspect_bazel_lib_dependencies()
+
+# Required rules_shell dependencies
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()
+
+# Register bazel-lib toolchains
+
+aspect_bazel_lib_register_toolchains()
+
+# Create the host platform repository transitively required by bazel-lib
+
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+    host_platform_repo,
+    name = "host_platform",
+)
+
+# rules_avro depends on rules_jvm_external: https://github.com/bazelbuild/rules_jvm_external
 RULES_JVM_EXTERNAL_TAG = "4.1"
 RULES_JVM_EXTERNAL_SHA = "f36441aa876c4f6427bfb2d1f2d723b48e9d930b62662bf723ddfb8fc80f0140"
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,40 @@ workspace(name = "io_bazel_rules_avro")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "63ae96db9b9ea3821320e4274352980387dc3218baeea0387f7cf738755d0f16",
+    strip_prefix = "bazel-lib-2.19.1",
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.19.1/bazel-lib-v2.19.1.tar.gz",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
+
+# Required bazel-lib dependencies
+
+aspect_bazel_lib_dependencies()
+
+# Required rules_shell dependencies
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()
+
+# Register bazel-lib toolchains
+
+aspect_bazel_lib_register_toolchains()
+
+# Create the host platform repository transitively required by bazel-lib
+
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+    host_platform_repo,
+    name = "host_platform",
+)
+
 RULES_JVM_EXTERNAL_TAG = "6.5"
 
 RULES_JVM_EXTERNAL_SHA = "3a4d56357851cf5b0dae538b3f3e0612a4f58925dfb3cadb2e0c4e87d51e629e"

--- a/avro/avro.bzl
+++ b/avro/avro.bzl
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:utils.bzl", "propagate_common_rule_attributes")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("@rules_jvm_external//:specs.bzl", "maven")
@@ -335,10 +336,11 @@ avro_gen = rule(
 )
 
 def avro_java_library(
-  name, srcs=[], type=None, strings=None, encoding=None, visibility=None, files_not_dirs=False, avro_libs=None, **kargs):
+  name, srcs=[], type=None, strings=None, encoding=None, visibility=None, files_not_dirs=False, avro_libs=None, **kwargs):
     libs = avro_libs if avro_libs else AVRO_LIBS_LABELS
     tools = libs["tools"]
     deps = [libs["core"]]
+    common_kwargs = propagate_common_rule_attributes(kwargs)
 
     avro_gen(
         name=name + '_srcjar',
@@ -348,7 +350,8 @@ def avro_java_library(
         encoding=encoding,
         files_not_dirs=files_not_dirs,
         visibility=visibility,
-        avro_tools=tools
+        avro_tools=tools,
+        **common_kwargs
     )
     args = {
         "name": name,
@@ -356,7 +359,7 @@ def avro_java_library(
         "deps": deps,
         "visibility": visibility,
     }
-    args.update(kargs)
+    args.update(kwargs)
     native.java_library(**args)
 
 def avro_idl_gen(
@@ -366,12 +369,15 @@ def avro_idl_gen(
         strings = None,
         encoding = None,
         visibility = None,
-        avro_tools = None):
+        avro_tools = None,
+        **kwargs):
+    common_kwargs = propagate_common_rule_attributes(kwargs)
     _avro_idl_gen(
         name = name + "_idl",
         srcs = srcs,
         imports = imports,
         avro_tools = avro_tools,
+        **common_kwargs
     )
 
     avro_gen(
@@ -383,6 +389,7 @@ def avro_idl_gen(
         visibility = visibility,
         files_not_dirs = True,
         avro_tools = avro_tools,
+        **common_kwargs
     )
 
 def avro_idl_java_library(
@@ -393,12 +400,13 @@ def avro_idl_java_library(
         encoding = None,
         visibility = None,
         avro_libs = None,
-        **kargs):
+        **kwargs):
     """Generate a Java library from an AVRO IDL definition"""
 
     libs = avro_libs if avro_libs else AVRO_LIBS_LABELS
     tools = libs["tools"]
     deps = [libs["core"]]
+    common_kwargs = propagate_common_rule_attributes(kwargs)
 
     avro_idl_gen(
         name = name + "_srcjar",
@@ -408,6 +416,7 @@ def avro_idl_java_library(
         encoding = encoding,
         visibility = visibility,
         avro_tools = tools,
+        **common_kwargs
     )
 
     args = {
@@ -416,5 +425,5 @@ def avro_idl_java_library(
         "deps": deps,
         "visibility": visibility
     }
-    args.update(kargs)
+    args.update(kwargs)
     native.java_library(**args)


### PR DESCRIPTION
Without these, attrs like `target_compatible` are not kicked in so it breaks things when we are building for different JDKs.

More information:
* https://github.com/bazel-contrib/bazel-lib/blob/main/docs/utils.md#propagate_common_rule_attributes
* https://bazel.build/reference/be/common-definitions#common-attributes